### PR TITLE
🔧 Add IoTrashOutline icon to Icon component

### DIFF
--- a/blublocks/src/components/Icon/Icon.stories.js
+++ b/blublocks/src/components/Icon/Icon.stories.js
@@ -39,6 +39,7 @@ const stories = {
           "IoSettingsOutline",
           "IoShareSocialOutline",
           "IoSpeedometerOutline",
+          "IoTrashOutline",
           "IoTrendingDownOutline",
           "IoTrendingUpOutline",
           "IoWarningOutline"

--- a/blublocks/src/components/Icon/Icon.test.js
+++ b/blublocks/src/components/Icon/Icon.test.js
@@ -14,4 +14,26 @@ describe("Icon", () => {
 
     expect(container.firstChild).toMatchSnapshot()
   })
+
+  it("renders size", () => {
+    const props = {
+      SelectedIcon: () => "SelectedIcon",
+      size: "32px"
+    }
+
+    const { container } = render(<Icon {...props} />)
+
+    expect(container.firstChild).toMatchSnapshot()
+  })
+
+  it("renders color", () => {
+    const props = {
+      SelectedIcon: () => "SelectedIcon",
+      color: "blue"
+    }
+
+    const { container } = render(<Icon {...props} />)
+
+    expect(container.firstChild).toMatchSnapshot()
+  })
 })

--- a/blublocks/src/components/Icon/__snapshots__/Icon.test.js.snap
+++ b/blublocks/src/components/Icon/__snapshots__/Icon.test.js.snap
@@ -1,6 +1,22 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Icon renders color 1`] = `
+<span
+  class="styled__Icon-sc-ztr6p6-0 gSA-dqd"
+>
+  SelectedIcon
+</span>
+`;
+
 exports[`Icon renders default size 1`] = `
+<span
+  class="styled__Icon-sc-ztr6p6-0 gSA-dqd"
+>
+  SelectedIcon
+</span>
+`;
+
+exports[`Icon renders size 1`] = `
 <span
   class="styled__Icon-sc-ztr6p6-0 gSA-dqd"
 >

--- a/blublocks/src/components/Icon/ionIcons.js
+++ b/blublocks/src/components/Icon/ionIcons.js
@@ -30,6 +30,7 @@ import { IoSearch } from "@react-icons/all-files/io5/IoSearch"
 import { IoSettingsOutline } from "@react-icons/all-files/io5/IoSettingsOutline"
 import { IoShareSocialOutline } from "@react-icons/all-files/io5/IoShareSocialOutline"
 import { IoSpeedometerOutline } from "@react-icons/all-files/io5/IoSpeedometerOutline"
+import { IoTrashOutline } from "@react-icons/all-files/io5/IoTrashOutline"
 import { IoTrendingDownOutline } from "@react-icons/all-files/io5/IoTrendingDownOutline"
 import { IoTrendingUpOutline } from "@react-icons/all-files/io5/IoTrendingUpOutline"
 import { IoWarningOutline } from "@react-icons/all-files/io5/IoWarningOutline"
@@ -65,6 +66,7 @@ const ionIcons = Object.freeze({
   IoSettingsOutline,
   IoShareSocialOutline,
   IoSpeedometerOutline,
+  IoTrashOutline,
   IoTrendingDownOutline,
   IoTrendingUpOutline,
   IoWarningOutline

--- a/flow-typed/npm/react-icons.js
+++ b/flow-typed/npm/react-icons.js
@@ -96,6 +96,9 @@ declare module "@react-icons/all-files/io5/IoShareSocialOutline" {
 declare module "@react-icons/all-files/io5/IoSpeedometerOutline" {
   declare export var IoSpeedometerOutline: React$ComponentType<IconProps>
 }
+declare module "@react-icons/all-files/io5/IoTrashOutline" {
+  declare export var IoTrashOutline: React$ComponentType<IconProps>
+}
 declare module "@react-icons/all-files/io5/IoTrendingDownOutline" {
   declare export var IoTrendingDownOutline: React$ComponentType<IconProps>
 }


### PR DESCRIPTION
- Added IoTrashOutline icon to the list of available icons in the Icon component.
- Updated Icon.stories.js and Icon.test.js to include tests for rendering size and color props.
- Updated ionIcons.js to import and export IoTrashOutline from react-icons package.
- Updated flow-typed/npm/react-icons.js to declare IoTrashOutline module.