### PR TITLE
🔧 Add support for ariaLabel in Button component

### DIFF
--- a/blublocks/src/components/buttons/Button/Button.js
+++ b/blublocks/src/components/buttons/Button/Button.js
@@ -1,5 +1,5 @@
 // @flow
-/* eslint-disable no-ternary, max-lines-per-function */
+/* eslint-disable no-ternary, max-lines-per-function, no-nested-ternary */
 
 import { Icon, IconEnd, IconStart, Wrapper } from "./styled"
 import type { ComponentProps } from "."
@@ -7,6 +7,7 @@ import Loading from "components/Loading"
 import React from "react"
 
 const Button = ({
+  ariaLabel,
   bold,
   className,
   disabled,
@@ -30,7 +31,7 @@ const Button = ({
 }: ComponentProps): React$Node => (
   <Wrapper
     aria-disabled={disabled ? "true" : "false"}
-    aria-label={iconOnly ? label : undefined}
+    aria-label={ariaLabel ? ariaLabel : iconOnly ? label : undefined}
     bold={bold}
     className={className}
     disabled={disabled}

--- a/blublocks/src/components/buttons/Button/Button.test.js
+++ b/blublocks/src/components/buttons/Button/Button.test.js
@@ -116,4 +116,15 @@ describe("Button", () => {
 
     expect(container.firstChild).toMatchSnapshot()
   })
+
+  it("renders aria label", () => {
+    const { container, getByLabelText } = render(
+      <Button {...props} ariaLabel="Aria Label" />
+    )
+
+    const button = getByLabelText("Aria Label")
+
+    expect(button).toBeInTheDocument()
+    expect(container.firstChild).toMatchSnapshot()
+  })
 })

--- a/blublocks/src/components/buttons/Button/__snapshots__/Button.test.js.snap
+++ b/blublocks/src/components/buttons/Button/__snapshots__/Button.test.js.snap
@@ -10,6 +10,17 @@ exports[`Button renders 1`] = `
 </button>
 `;
 
+exports[`Button renders aria label 1`] = `
+<button
+  aria-disabled="false"
+  aria-label="Aria Label"
+  class="Reset__Button-sc-ohlhxz-0 styled__Wrapper-sc-pzlzbh-0 eNpAQb jmfcCj"
+  type="button"
+>
+  Button
+</button>
+`;
+
 exports[`Button renders bold 1`] = `
 <button
   aria-disabled="false"

--- a/flow-typed/@bluframe/blublocks.js
+++ b/flow-typed/@bluframe/blublocks.js
@@ -99,6 +99,7 @@ declare module "@bluframe/blublocks" {
   |}
 
   declare type ButtonProps = {|
+    +ariaLabel?: string,
     +bold?: boolean,
     +className?: string,
     +disabled?: boolean,


### PR DESCRIPTION
The Button component now accepts an optional `ariaLabel` prop, which allows specifying an ARIA label for the button. This change ensures that the button is accessible to screen readers when necessary.

This commit also includes updates to related test files and snapshots.

