### PR TITLE
🔤 Increased font size in TextArea component

### DIFF
--- a/blublocks/src/components/inputs/TextArea/styled.js
+++ b/blublocks/src/components/inputs/TextArea/styled.js
@@ -55,7 +55,7 @@ export const Label: StyledComponent<
   HTMLLabelElement
 > = styled.label`
   color: ${({ theme }) => theme.palette.text.light};
-  font-size: 14px;
+  font-size: 16px;
   left: 16px;
   pointer-events: none;
   position: absolute;


### PR DESCRIPTION
The font size for the TextArea component has been increased from 14px to 16px. This change will improve readability and user experience.