### PR TITLE
🔧 Enhanced InputText component with 'hasContent' and 'onInput' props

### DIFF
--- a/blublocks/src/components/inputs/InputText/InputText.js
+++ b/blublocks/src/components/inputs/InputText/InputText.js
@@ -12,6 +12,7 @@ const InputText: React$AbstractComponent<ComponentProps, React$Node> =
         className,
         defaultValue,
         error,
+        hasContent,
         helperText,
         inputId,
         isFullBorder,
@@ -20,6 +21,7 @@ const InputText: React$AbstractComponent<ComponentProps, React$Node> =
         name,
         onBlur,
         onChange,
+        onInput,
         required,
         step,
         type = "text",
@@ -30,6 +32,7 @@ const InputText: React$AbstractComponent<ComponentProps, React$Node> =
       <Wrapper className={className}>
         <Input
           $error={error}
+          $hasContent={hasContent}
           aria-invalid={error ? "true" : "false"}
           defaultValue={defaultValue}
           id={inputId}
@@ -37,6 +40,7 @@ const InputText: React$AbstractComponent<ComponentProps, React$Node> =
           name={name}
           onBlur={onBlur}
           onChange={onChange}
+          onInput={onInput}
           ref={ref}
           required={required}
           step={step}

--- a/blublocks/src/components/inputs/InputText/InputText.test.js
+++ b/blublocks/src/components/inputs/InputText/InputText.test.js
@@ -10,12 +10,14 @@ jest.mock(".", () => ({}))
 
 describe("InputText", () => {
   const props: ComponentProps = {
+    hasContent: false,
     inputId: "name-input",
     label: "Name",
     labelId: "name-label",
     name: "name",
     onBlur: jest.fn(),
-    onChange: jest.fn()
+    onChange: jest.fn(),
+    onInput: jest.fn()
   }
 
   it("renders with defaultValue", () => {

--- a/blublocks/src/components/inputs/InputText/index.js
+++ b/blublocks/src/components/inputs/InputText/index.js
@@ -3,6 +3,7 @@
 import InputText from "./InputText"
 import type { InputTextProps } from "@bluframe/blublocks"
 import { prepareComponent } from "@bluframe/grapple"
+import { useState } from "react"
 
 export type Props = {|
   ...InputTextProps
@@ -10,11 +11,16 @@ export type Props = {|
 
 export type ComponentProps = {|
   ...Props,
-  +labelId?: string
+  +hasContent: boolean,
+  +labelId?: string,
+  onInput: (event: SyntheticInputEvent<HTMLInputElement>) => void
 |}
+
+const ZERO = 0
 
 const usePrepareComponent = (props: Props): ComponentProps => {
   const labelId = props.inputId && `${props.inputId}-label`
+  const [hasValue, setHasValue] = useState(null)
 
   const onBlur = (event: SyntheticEvent<*>) => {
     if (props.onBlur) {
@@ -28,11 +34,19 @@ const usePrepareComponent = (props: Props): ComponentProps => {
     }
   }
 
+  const onInput = (event) => {
+    setHasValue(event.target.value.length > ZERO)
+  }
+
+  const hasContent = Boolean(hasValue ?? props.defaultValue ?? props.value)
+
   return {
     ...props,
+    hasContent,
     labelId,
     onBlur,
-    onChange
+    onChange,
+    onInput
   }
 }
 

--- a/blublocks/src/components/inputs/InputText/styled.js
+++ b/blublocks/src/components/inputs/InputText/styled.js
@@ -1,7 +1,7 @@
 // @flow
 /* eslint-disable no-ternary */
 
-import styled, { type StyledComponent } from "styled-components"
+import styled, { type StyledComponent, css } from "styled-components"
 import type { Theme } from "@bluframe/blublocks"
 
 export const Wrapper: StyledComponent<{||}, Theme, HTMLDivElement> = styled.div`
@@ -11,14 +11,18 @@ export const Wrapper: StyledComponent<{||}, Theme, HTMLDivElement> = styled.div`
   width: 100%;
 `
 
+const labelShrinkCss = css`
+  font-size: 12px;
+  left: 16px;
+  top: ${({ isFullBorder }) => (isFullBorder ? "-24px" : "0")};
+  transition: all 200ms;
+`
+
 export const Input: StyledComponent<
   {| +isFullBorder?: boolean |},
   Theme,
   HTMLInputElement
-> = styled.input.attrs(({ defaultValue, value }) => ({
-  $hasContent: defaultValue ?? value,
-  placeholder: " "
-}))`
+> = styled.input.attrs({ placeholder: " " })`
   ${({ $error, isFullBorder, theme }) =>
     isFullBorder
       ? `border: 1px solid ${
@@ -50,13 +54,18 @@ border-bottom: 1px solid ${theme.palette.primary.main};
     box-shadow: none;
   }
 
-  :not(:placeholder-shown) + label,
-  &:focus + label,
-  ${({ $hasContent }) => $hasContent && "& + label"} {
-    font-size: 12px;
-    left: 16px;
-    top: ${({ isFullBorder }) => (isFullBorder ? "-24px" : "0")};
+  &:not(:placeholder-shown) + label,
+  &:focus + label {
+    ${labelShrinkCss}
   }
+
+  ${({ $hasContent }) =>
+    $hasContent &&
+    css`
+      & + label {
+        ${labelShrinkCss}
+      }
+    `}
 `
 
 export const Label: StyledComponent<


### PR DESCRIPTION
The InputText component has been updated to include two new properties: 'hasContent' and 'onInput'. The 'hasContent' prop is a boolean that indicates whether the input field contains any text, while the 'onInput' prop is a function that updates the state of the component when user input is detected. This change also includes modifications to related test files to accommodate these new properties. Additionally, CSS styles have been adjusted for better visual feedback based on the presence of content in the input field.